### PR TITLE
fix for issue with readRDS() connections not closing

### DIFF
--- a/R/get_wcde_single.R
+++ b/R/get_wcde_single.R
@@ -65,10 +65,12 @@ get_wcde_single <- function(indicator = NULL, scenario = 2, country_code = NULL,
   read_with_progress <- function(f){
     pb$tick()
     # message(f)
-    f %>%
-      url() %>%
-      readRDS()
+    con <- f %>%
+      url()
+    df <- readRDS(con)
+    close(con)
     # readr::read_csv(f, col_types = readr::cols(), guess_max = 1e5, progress = FALSE)
+    return(df)
   }
 
   # server <- match.arg(server)


### PR DESCRIPTION
Implemented change to the read_with_progress function to close the readRDS() connections after each read, as pointed out and suggested in issue #5 